### PR TITLE
Support for mongoose 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "mongoose": "3.8.x"
+    "mongoose": "^4.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -109,7 +109,7 @@ describe('MongooseNumber', function(){
         var m = new M({ num: [] });
         m.save(function (err) {
           assert.ok(err);
-          assert.equal('MongooseNumber', err.type);
+          assert.equal('Number', err.kind);
           assert.equal('CastError', err.name);
           done();
         });


### PR DESCRIPTION
This PR updates the `devDependency` in `mongoose-number` to version `4.x`, the latest version.

The library will still continue to work with older versions of the library, but will run tests against Mongoose 4. 

After the change, one test needed to be changed to work around `err.type` being changed to `err.kind` as described in http://mongoosejs.com/docs/migration.html
